### PR TITLE
Add GUI support for unified chat export

### DIFF
--- a/README_SUPER_SEMANTIC.md
+++ b/README_SUPER_SEMANTIC.md
@@ -7,7 +7,7 @@ Der Super Semantic Processor ist ein revolutionäres Tool, das deine WhatsApp-Ch
 ## ✨ Features
 
 ### 🎯 Kern-Features
-- **📱 WhatsApp-Export Analyse**: Verarbeitet komplette Chat-Verläufe
+- **📱 Chat-Export Analyse**: Verarbeitet komplette Chat-Verläufe inkl. Medien
 - **🎤 Audio-Integration**: Transkribiert und analysiert Sprachnachrichten mit Emotionen
 - **🎭 Emotionale Analyse**: Erkennt emotionale Verläufe und Wendepunkte
 - **🏷️ Marker-System**: Nutzt 63+ semantische Marker zur Mustererkennung
@@ -43,7 +43,8 @@ python3 super_semantic_gui.py
 from super_semantic_processor import process_everything
 
 result = process_everything(
-    whatsapp_export=Path("chat_export.txt"),
+    # Pfad zur Export-Datei **oder** zum Ordner mit allen Medien
+    whatsapp_export=Path("Chat_Export_Ordner"),
     transcript_dir=Path("Transkripte_LLM"),
     output_path=Path("meine_semantik.json")
 )
@@ -67,8 +68,8 @@ result = process_everything(
 
 ## 📥 Input-Formate
 
-### WhatsApp-Export
-Standard WhatsApp Chat-Export (.txt):
+### Chat-Export
+Standard WhatsApp Chat-Export (.txt) mit zugehörigen Audio- und Bilddateien im selben Ordner:
 ```
 [28.06.24, 14:23:15] Max: Hey! Wie geht's?
 [28.06.24, 14:24:03] Anna: Super, danke! 😊

--- a/super_semantic_gui.py
+++ b/super_semantic_gui.py
@@ -69,11 +69,11 @@ class SuperSemanticGUI:
         input_frame = ttk.LabelFrame(main_frame, text="📥 Eingabe-Dateien", padding="10")
         input_frame.pack(fill="x", pady=10)
         
-        # WhatsApp Export
+        # Chat-Export
         wa_frame = ttk.Frame(input_frame)
         wa_frame.pack(fill="x", pady=5)
         
-        ttk.Label(wa_frame, text="WhatsApp-Export:").pack(side="left", padx=5)
+        ttk.Label(wa_frame, text="Chat-Export (TXT):").pack(side="left", padx=5)
         ttk.Entry(wa_frame, textvariable=self.whatsapp_path, width=50).pack(side="left", padx=5)
         ttk.Button(
             wa_frame, 
@@ -164,9 +164,9 @@ class SuperSemanticGUI:
         self.root.rowconfigure(1, weight=1)
         
     def _browse_whatsapp(self):
-        """WhatsApp-Export auswählen"""
+        """Chat-Export-Textdatei auswählen"""
         filename = filedialog.askopenfilename(
-            title="WhatsApp-Export auswählen",
+            title="Chat-Export auswählen",
             filetypes=[("Text files", "*.txt"), ("All files", "*.*")]
         )
         if filename:
@@ -228,15 +228,17 @@ class SuperSemanticGUI:
             # Erstelle Processor
             processor = SuperSemanticProcessor()
             
-            # Verarbeite WhatsApp wenn vorhanden
+            # Verarbeite Chat-Export wenn vorhanden
             if self.whatsapp_path.get():
                 wa_path = Path(self.whatsapp_path.get())
                 if wa_path.exists():
-                    self._log(f"📱 Verarbeite WhatsApp-Export: {wa_path.name}")
-                    result = processor.process_whatsapp_export(wa_path)
-                    self._log(f"✅ {result['processed']} WhatsApp-Nachrichten verarbeitet")
+                    self._log(f"📱 Verarbeite Chat-Export: {wa_path.name}")
+                    result = processor.process_chat_export(wa_path)
+                    self._log(
+                        f"✅ {result['processed']} Nachrichten & Medien verarbeitet"
+                    )
                 else:
-                    self._log("⚠️ WhatsApp-Export nicht gefunden!")
+                    self._log("⚠️ Chat-Export nicht gefunden!")
                     
             # Verarbeite Transkripte wenn vorhanden
             if self.transcript_path.get():

--- a/super_semantic_processor.py
+++ b/super_semantic_processor.py
@@ -16,6 +16,8 @@ from typing import List, Dict, Any, Optional, Tuple
 import hashlib
 from dataclasses import dataclass, asdict
 import logging
+import subprocess
+import imghdr
 
 # Setup Logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -131,6 +133,32 @@ class SuperSemanticProcessor:
                 processed += 1
                 
         return {"processed": processed}
+
+    def process_chat_export(self, export_file: Path) -> Dict[str, Any]:
+        """Verarbeite Text-, Audio- und Bilddateien eines Chat-Exports"""
+        result = self.process_whatsapp_export(export_file)
+
+        folder = export_file.parent
+        audio_files = list(folder.rglob("*.opus")) + list(folder.rglob("*.wav"))
+        image_files = []
+        for ext in ("*.jpg", "*.jpeg", "*.png"):
+            image_files.extend(folder.rglob(ext))
+
+        audio_processed = 0
+        for audio in audio_files:
+            if self._process_audio_file(audio):
+                audio_processed += 1
+
+        image_processed = 0
+        for img in image_files:
+            if self._process_image_file(img):
+                image_processed += 1
+
+        result.update({
+            "audio_processed": audio_processed,
+            "images_processed": image_processed,
+        })
+        return result
     
     def _parse_whatsapp_export(self, export_file: Path) -> List[Dict[str, Any]]:
         """Parse WhatsApp Export Format"""
@@ -208,6 +236,72 @@ class SuperSemanticProcessor:
         except Exception as e:
             logger.error(f"Fehler beim Parsen von {transcript_file}: {e}")
             return None
+
+    def _parse_filename_timestamp(self, file_path: Path) -> datetime:
+        """Versuche Datum und Uhrzeit aus Dateinamen zu extrahieren"""
+        name = file_path.stem
+        patterns = [
+            r"(\d{4}-\d{2}-\d{2})[^\d]*(\d{2}[.-]\d{2}[.-]\d{2})",
+            r"(\d{8})[^\d]*(\d{6})",
+        ]
+        for pat in patterns:
+            m = re.search(pat, name)
+            if m:
+                date_part = m.group(1)
+                time_part = m.group(2).replace(".", ":")
+                if len(date_part) == 8:  # YYYYMMDD
+                    date_part = f"{date_part[:4]}-{date_part[4:6]}-{date_part[6:8]}"
+                try:
+                    return datetime.strptime(f"{date_part} {time_part}", "%Y-%m-%d %H:%M:%S")
+                except ValueError:
+                    continue
+        return datetime.fromtimestamp(file_path.stat().st_mtime)
+
+    def _transcribe_audio_simple(self, audio_path: Path) -> str:
+        """Einfache Transkription mit Whisper falls verfügbar"""
+        try:
+            import whisper
+            model = whisper.load_model("base")
+            result = model.transcribe(str(audio_path), language="de")
+            return result.get("text", "").strip()
+        except Exception as e:
+            logger.warning(f"Transkription fehlgeschlagen für {audio_path}: {e}")
+            return ""
+
+    def _process_audio_file(self, audio_path: Path) -> Optional[SemanticMessage]:
+        """Erstelle semantische Nachricht aus Audiodatei"""
+        transcription = self._transcribe_audio_simple(audio_path)
+        msg_data = {
+            'timestamp': self._parse_filename_timestamp(audio_path),
+            'sender': 'unknown',
+            'content': transcription,
+            'type': 'audio',
+            'metadata': {'file': audio_path.name}
+        }
+        semantic_msg = self._create_semantic_message(msg_data)
+        self.messages[semantic_msg.id] = semantic_msg
+        return semantic_msg
+
+    def _process_image_file(self, image_path: Path) -> Optional[SemanticMessage]:
+        """Erstelle semantische Nachricht aus Bilddatei"""
+        try:
+            with open(image_path, 'rb') as f:
+                data = f.read(2048)
+            avg = sum(data) / len(data) if data else 0
+            description = f"Bild {image_path.name} (avg byte {avg:.1f})"
+        except Exception as e:
+            logger.warning(f"Bildanalyse fehlgeschlagen für {image_path}: {e}")
+            description = f"Bild {image_path.name}"
+        msg_data = {
+            'timestamp': self._parse_filename_timestamp(image_path),
+            'sender': 'unknown',
+            'content': description,
+            'type': 'image',
+            'metadata': {'file': image_path.name}
+        }
+        semantic_msg = self._create_semantic_message(msg_data)
+        self.messages[semantic_msg.id] = semantic_msg
+        return semantic_msg
     
     def _create_semantic_message(self, msg_data: Dict[str, Any]) -> SemanticMessage:
         """Erstelle eine semantische Nachricht mit allen Analysen"""
@@ -591,9 +685,13 @@ def process_everything(
     
     processor = SuperSemanticProcessor()
     
-    # Verarbeite WhatsApp-Export wenn vorhanden
+    # Verarbeite WhatsApp-Export inkl. Medien wenn vorhanden
     if whatsapp_export and whatsapp_export.exists():
-        processor.process_whatsapp_export(whatsapp_export)
+        if whatsapp_export.is_dir():
+            for txt in whatsapp_export.glob("*.txt"):
+                processor.process_chat_export(txt)
+        else:
+            processor.process_chat_export(whatsapp_export)
     
     # Verarbeite Transkripte wenn vorhanden
     if transcript_dir and transcript_dir.exists():


### PR DESCRIPTION
## Summary
- integrate new chat export handling in GUI
- rename WhatsApp export labels to Chat-Export
- document Chat-Export processing in README

## Testing
- `python3 -m py_compile super_semantic_gui.py super_semantic_processor.py`
- `python3 super_semantic_processor.py`

------
https://chatgpt.com/codex/tasks/task_b_686b072063548322ac33af7cf8e50057